### PR TITLE
Fix deprecrecation warning

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -11,7 +11,7 @@ import (
 // New actions/auth.go file configured to the specified providers.
 func New() (*makr.Generator, error) {
 	g := makr.New()
-	files, err := generators.Find(filepath.Join("github.com", "gobuffalo", "buffalo-auth", "auth"))
+	files, err := generators.FindByBox(filepath.Join("github.com", "gobuffalo", "buffalo-auth", "auth"))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
$ buffalo generate auth
INFO[0000] Find is deprecated, and will be removed in v0.12.0. Use generators.FindByBox instead. Called from /home/rob/gocode/src/github.com/gobuffalo/buffalo-auth/auth/auth.go:14