### PR TITLE
Use github.com/gobuffalo/uuid in auth template

### DIFF
--- a/auth/templates/models/user.go.tmpl
+++ b/auth/templates/models/user.go.tmpl
@@ -6,10 +6,10 @@ import (
 	"time"
 
 	"github.com/gobuffalo/pop"
+	"github.com/gobuffalo/uuid"
 	"github.com/gobuffalo/validate"
 	"github.com/gobuffalo/validate/validators"
 	"github.com/pkg/errors"
-	"github.com/satori/go.uuid"
 	"golang.org/x/crypto/bcrypt"
 )
 


### PR DESCRIPTION
The auth template is still importing `github.com/satori/go.uuid`. This PR replaces the import with`github.com/gobuffalo/uuid`.