### PR TITLE
Task adding docker integration test

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -81,3 +81,12 @@ jobs:
         GO111MODULE: "off"
   steps:
     - template: azure-tests.yml
+
+- job: Linux
+  pool:
+    vmImage: "ubuntu-16.04"
+  steps:
+    - task: Docker@2
+      displayName: Integration
+      inputs:
+        command: build

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -64,7 +64,7 @@ jobs:
   steps:
     - template: azure-tests.yml
 
-- job: Linux
+- job: Integration
   pool:
     vmImage: "ubuntu-16.04"
   steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,12 +9,6 @@ jobs:
     vmImage: "vs2017-win2016"
   strategy:
     matrix:
-      go 1.11 (on):
-        go_version: "1.11.13"
-        GO111MODULE: "on"
-      go 1.11 (off):
-        go_version: "1.11.13"
-        GO111MODULE: "off"
       go 1.12 (on):
         go_version: "1.12"
         GO111MODULE: "on"
@@ -35,12 +29,6 @@ jobs:
     vmImage: "macOS-10.13"
   strategy:
     matrix:
-      go 1.11 (on):
-        go_version: "1.11.13"
-        GO111MODULE: "on"
-      go 1.11 (off):
-        go_version: "1.11.13"
-        GO111MODULE: "off"
       go 1.12 (on):
         go_version: "1.12"
         GO111MODULE: "on"
@@ -61,12 +49,6 @@ jobs:
     vmImage: "ubuntu-16.04"
   strategy:
     matrix:
-      go 1.11 (on):
-        go_version: "1.11.13"
-        GO111MODULE: "on"
-      go 1.11 (off):
-        go_version: "1.11.13"
-        GO111MODULE: "off"
       go 1.12 (on):
         go_version: "1.12"
         GO111MODULE: "on"


### PR DESCRIPTION
One of the things I noticed while solving #54 was that our integration tests were not being run by azure. This PR adds that Dockerfile build and changes the versions to run there to be last 2 go versions.

> 1.12 and 1.13