### PR TITLE
changed behavior for missing user, in the `SetCurrentUser` middleware

### DIFF
--- a/genny/auth/templates/actions/users.go.plush
+++ b/genny/auth/templates/actions/users.go.plush
@@ -51,7 +51,12 @@ func SetCurrentUser(next buffalo.Handler) buffalo.Handler {
 			tx := c.Value("tx").(*pop.Connection)
 			err := tx.Find(u, uid)
 			if err != nil {
-				return errors.WithStack(err)
+				c.Logger().Warnf("user attempted to access with current_user_id '%v' that is not found: %v", uid, err)
+
+				c.Session().Delete("current_user_id")
+				c.Session().Set("redirectURL", c.Request().URL.String())
+				c.Flash().Add("danger", "You must be authorized with a correct user to see that page")
+				return c.Redirect(http.StatusFound, "/auth/new")
 			}
 			c.Set("current_user", u)
 		}


### PR DESCRIPTION
### What is being done in this PR?

In the scaffolded `actions/users.go`, middleware `SetCurrentUser` just returned a general error which causes a `404` error. However, it could be better if the middleware generates `Unauthorized` or just redirects users to the login page. With this change, the middleware redirects the user to the login page.

fixes #30

see also: https://github.com/gobuffalo/buffalo-auth/issues/30#issuecomment-1416676908

### What are the main choices made to get to this solution?

- the selected solution is redirecting the user to the login page. it could be nice for interactive applications.
- however, since this is just a scaffold code, users can modify their application with their own use cases.

### List the manual test cases you've covered before sending this PR:

- tested with a simple todo application