### PR TITLE
fixed the bug in the extra args handling

### DIFF
--- a/genny/auth/auth.go
+++ b/genny/auth/auth.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"embed"
 	"fmt"
+	"html/template"
 	"io/fs"
 	"path/filepath"
 	"strings"
@@ -29,13 +30,13 @@ func extraAttrs(args []string) []string {
 	var result = []string{}
 	for _, field := range args {
 		at, _ := attrs.Parse(field)
-		field = at.Name.Underscore().String()
+		name := at.Name.Underscore().String()
 
-		if names[field] != "" {
+		if names[name] != "" {
 			continue
 		}
 
-		names[field] = field
+		names[name] = name
 		result = append(result, field)
 	}
 
@@ -65,6 +66,12 @@ func New(args []string) (*genny.Generator, error) {
 	ctx := plush.NewContext()
 	ctx.Set("app", meta.New("."))
 	ctx.Set("attrs", fields)
+	ctx.Set("option", func(attr attrs.Attr) template.HTML {
+		if strings.HasPrefix(attr.GoType(), "nulls.") {
+			return "\"null\": true"
+		}
+		return ""
+	})
 
 	g.Transformer(plushgen.Transformer(ctx))
 	g.Transformer(genny.NewTransformer(".html", newUserHTMLTransformer))

--- a/genny/auth/templates/migrations/create_users.up.fizz.plush
+++ b/genny/auth/templates/migrations/create_users.up.fizz.plush
@@ -2,5 +2,5 @@ create_table("users"){
     t.Column("id", "uuid", {"primary": true})
     t.Column("email", "string", {})
     t.Column("password_hash", "string", {})
-<%= for (attr) in attrs { %>    t.Column("<%= attr.Name.Underscore() %>", "<%= attr.CommonType() %>", {})
+<%= for (attr) in attrs { %>    t.Column("<%= attr.Name.Underscore() %>", "<%= attr.CommonType() %>", {<%= option(attr) %>})
 <% } %>}


### PR DESCRIPTION
### What is being done in this PR?

Currently, the type of all extra columns is set as `string` which is the default and the `null` handling is not working. With this fix,
- the type for the extra fields is preserved and properly applied to both the model and migration file
- if the type is nullable, a form of `nulls.Type` supported by module `nulls`, the migration will allow the null value. 

Now the generated files are something like

```go
type User struct {
	ID           uuid.UUID `json:"id" db:"id"`
	CreatedAt    time.Time `json:"created_at" db:"created_at"`
	UpdatedAt    time.Time `json:"updated_at" db:"updated_at"`
	Email        string    `json:"email" db:"email"`
	PasswordHash string    `json:"password_hash" db:"password_hash"`

	Password             string `json:"-" db:"-"`
	PasswordConfirmation string `json:"-" db:"-"`

	//Extra fields
	Age int          `json:"age" db:"age"`
	Bio nulls.String `json:"bio" db:"bio"`
}
```


```fizz
create_table("users"){
    t.Column("id", "uuid", {"primary": true})
    t.Column("email", "string", {})
    t.Column("password_hash", "string", {})
    t.Column("age", "integer", {})
    t.Column("bio", "text", {"null": true})
}
```

for the same command used in #21, `buffalo g auth age:int bio:nulls.Text`.

fixes #21

### What are the main choices made to get to this solution?

Actually, there could be better options such as integration with fizz, and improving the function and the logic used for extra arguments handling, but I just simply fixed the bug with a smaller modification while keeping the current implementation as is today.

### List the manual test cases you've covered before sending this PR:

Manual test with a simple todo app.